### PR TITLE
Adding error checking to make sure toggles exist on the page

### DIFF
--- a/a11y-toggle.js
+++ b/a11y-toggle.js
@@ -1,28 +1,31 @@
 (function () {
   var toggles = document.querySelectorAll('[data-a11y-toggle][aria-controls]');
-  var targetsList = [];
+  
+  if (toggles.length > 0) {
+    var targetsList = [];
 
-  for (var i = 0; i < toggles.length; i += 1) {
-    var toggle = toggles[i];
-    targetsList.push('#' + toggle.getAttribute('aria-controls'));
-    toggle.hasAttribute('aria-expanded') || toggle.setAttribute('aria-expanded', false);
+    for (var i = 0; i < toggles.length; i += 1) {
+      var toggle = toggles[i];
+      targetsList.push('#' + toggle.getAttribute('aria-controls'));
+      toggle.hasAttribute('aria-expanded') || toggle.setAttribute('aria-expanded', false);
+    }
+
+    var targets = document.querySelectorAll(targetsList);
+    var targetsMap = {};
+
+    for (var j = 0; j < targets.length; j += 1) {
+      var target = targets[j];
+      targetsMap[target.id] = target;
+      target.hasAttribute('aria-hidden') || target.setAttribute('aria-hidden', true);
+    }
+
+    document.addEventListener('click', function (event) {
+      var toggle = event.target;
+      var target = targetsMap[toggle.getAttribute('aria-controls')];
+      var isExpanded = JSON.parse(toggle.getAttribute('aria-expanded'));
+
+      toggle.setAttribute('aria-expanded', !isExpanded);
+      target.setAttribute('aria-hidden', isExpanded);
+    });
   }
-
-  var targets = document.querySelectorAll(targetsList);
-  var targetsMap = {};
-
-  for (var j = 0; j < targets.length; j += 1) {
-    var target = targets[j];
-    targetsMap[target.id] = target;
-    target.hasAttribute('aria-hidden') || target.setAttribute('aria-hidden', true);
-  }
-
-  document.addEventListener('click', function (event) {
-    var toggle = event.target;
-    var target = targetsMap[toggle.getAttribute('aria-controls')];
-    var isExpanded = JSON.parse(toggle.getAttribute('aria-expanded'));
-
-    toggle.setAttribute('aria-expanded', !isExpanded);
-    target.setAttribute('aria-hidden', isExpanded);
-  });
 }());


### PR DESCRIPTION
When adding the original toggle script to a starter set of pages which did not have toggle links set up yet, I noticed that the script was throwing Javascript errors because it was attempting to perform operations on an array (`toggles`) with no data.  I've added an error check for toggles.length to see if there are any toggles available, and nested the rest of the functionality within that error check so that it only runs if there are toggles.  That way, the script can be included early on in the dev process and not create errors that might block other scripts from running.  Let me know if you have any questions about this commit -- thanks!
