### PR TITLE
Make the npm page show a link back to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.1",
   "description": "A tiny script to make accessible content toggles.",
   "homepage": "https://github.com/edenspiekermann/a11y-toggle",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/edenspiekermann/a11y-toggle.git"
+  },
   "main": "a11y-toggle.js",
   "keywords": [
     "toggle",


### PR DESCRIPTION
Right now it doesn't show a link back to the Github repo on the npm page.
